### PR TITLE
Fix/kar 356 insided tap sync user activities

### DIFF
--- a/tap_insided/endpoints.py
+++ b/tap_insided/endpoints.py
@@ -130,7 +130,7 @@ ENDPOINTS_CONFIG = {
     'user_activities': {
         'path': '/user/activity',
         'pk': ['event_uuid'],
-        'number_indexed': True,
+        'is_list': True,
         'unix_timestamps': True
     }
 }

--- a/tap_insided/schemas/user_activities.json
+++ b/tap_insided/schemas/user_activities.json
@@ -88,31 +88,6 @@
         "null",
         "boolean"
       ]
-    },
-    "pageinfo": {
-      "oneOf": [
-        {
-          "type": [
-            "null",
-            "object"
-          ]
-        },
-        {
-          "type": [
-            "null",
-            "array"
-          ]
-        }
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "post_id": {
-          "type": [
-            "null",
-            "string"
-          ]
-        }
-      }
     }
   }
 }

--- a/tap_insided/schemas/user_activities.json
+++ b/tap_insided/schemas/user_activities.json
@@ -36,7 +36,12 @@
       "type": [
         "null",
         "array"
-      ]
+      ],
+      "items": {
+        "type": [
+          "string"
+        ]
+      }
     },
     "time_added": {
       "type": [
@@ -85,9 +90,19 @@
       ]
     },
     "pageinfo": {
-      "type": [
-        "null",
-        "object"
+      "oneOf": [
+        {
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        {
+          "type": [
+            "null",
+            "array"
+          ]
+        }
       ],
       "additionalProperties": false,
       "properties": {

--- a/tap_insided/schemas/user_activities.json
+++ b/tap_insided/schemas/user_activities.json
@@ -36,12 +36,7 @@
       "type": [
         "null",
         "array"
-      ],
-      "items": {
-        "type": [
-          "string"
-        ]
-      }
+      ]
     },
     "time_added": {
       "type": [

--- a/tap_insided/schemas/user_activities.json
+++ b/tap_insided/schemas/user_activities.json
@@ -98,13 +98,6 @@
           ]
         }
       }
-    },
-    "time_processed": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
     }
   }
 }

--- a/tap_insided/sync.py
+++ b/tap_insided/sync.py
@@ -82,6 +82,9 @@ def sync_endpoint(client,
                     records.append(value)
                 except:
                     pass
+        elif endpoint.get('is_list', False) == True:
+            if isinstance(data, list):
+                records = data
         else:
             records = data['result']
             if not isinstance(records, list):


### PR DESCRIPTION
This PR addresses issues discovered when running the Insided Singer tap via Meltano.

- removes the `page_info` object
- fixes issues with the sync logic when the API returns a list of objects